### PR TITLE
fixed  relationship's mappedKeyName.[0-9] Invalid

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalDataImport.m
@@ -172,7 +172,7 @@ NSString * const kMagicalRecordImportAttributeUseDefaultValueWhenNotPresent = @"
 
         NSRelationshipDescription *relationshipInfo = [relationships valueForKey:relationshipName];
 
-        NSString *lookupKey = [relationshipData MR_lookupKeyForRelationship:relationshipInfo]?: relationshipName;
+        NSString *lookupKey = [relationshipData MR_lookupKeyForAttribute:relationshipInfo]?: relationshipName;
 
         id relatedObjectData;
 


### PR DESCRIPTION
修复导入时, 关系映射无法有效指定多个keypath的bug.